### PR TITLE
Add Feature: Embedd images into the email

### DIFF
--- a/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Newsletters/Configuration/configPage.html
@@ -98,6 +98,7 @@
                                 <select is="emby-select" id="HostingSelector" name="HostingSelector" class="emby-select-withcolor emby-select">
                                     <option id="defaultImgur" value="Imgur">Imgur (Default)</option>
                                     <option id="localJFHosting" value="JfHosting">Local JF Hosting</option>
+                                    <option id="embedded" value="Embedded">Embedded</option>
                                 </select>
                             </div>
                             <hr>
@@ -118,6 +119,8 @@
                                         I.e: https://myServerDNSName.com:8096
                                     </div>
                                 </div>
+                            </div>
+                            <div id="Embedded" name="options">
                             </div>
                         </details>
                     </div>

--- a/Jellyfin.Plugin.Newsletters/Scanner/PosterImageHandler.cs
+++ b/Jellyfin.Plugin.Newsletters/Scanner/PosterImageHandler.cs
@@ -60,6 +60,9 @@ public class PosterImageHandler
             case "JfHosting":
                 return $"{config.Hostname}/Items/{item.ItemID}/Images/Primary";
                 break;
+            case "Embedded":
+                return "data:image/jpeg;base64, " + Convert.ToBase64String(File.ReadAllBytes(item.PosterPath));
+                break;
             default:
                 return "Something Went Wrong";
                 break;


### PR DESCRIPTION
The image is added as base64 encoded string into the email. It is assumed that the images are always JPEGs. In case this assumption is not true anymore, the code within PosterImageHandler.cs requires some modification.