### PR TITLE
Add ReplyTo Value to Emails

### DIFF
--- a/Jellyfin.Plugin.Newsletters/Emails/smtp.cs
+++ b/Jellyfin.Plugin.Newsletters/Emails/smtp.cs
@@ -49,6 +49,7 @@ public class Smtp : ControllerBase
             mail = new MailMessage();
 
             mail.From = new MailAddress(config.FromAddr);
+            mail.ReplyToList = new MailAdddress(config.FromAddr);
             mail.To.Clear();
             mail.Subject = "Jellyfin Newsletters - Test";
             mail.Body = "Success! You have properly configured your email notification settings";
@@ -105,6 +106,7 @@ public class Smtp : ControllerBase
                 builtString = builtString.Replace("{Date}", currDate, StringComparison.Ordinal);
 
                 mail.From = new MailAddress(emailFromAddress, emailFromAddress);
+                mail.ReplyToList = new MailAddress(emailFromAddress, emailFromAddress);
                 mail.To.Clear();
                 mail.Subject = subject;
                 mail.Body = Regex.Replace(builtString, "{[A-za-z]*}", " "); // Final cleanup

--- a/Jellyfin.Plugin.Newsletters/Emails/smtp.cs
+++ b/Jellyfin.Plugin.Newsletters/Emails/smtp.cs
@@ -49,7 +49,7 @@ public class Smtp : ControllerBase
             mail = new MailMessage();
 
             mail.From = new MailAddress(config.FromAddr);
-            mail.ReplyToList = new MailAdddress(config.FromAddr);
+            mail.ReplyToList.Add = new MailAdddress(config.FromAddr);
             mail.To.Clear();
             mail.Subject = "Jellyfin Newsletters - Test";
             mail.Body = "Success! You have properly configured your email notification settings";
@@ -106,7 +106,7 @@ public class Smtp : ControllerBase
                 builtString = builtString.Replace("{Date}", currDate, StringComparison.Ordinal);
 
                 mail.From = new MailAddress(emailFromAddress, emailFromAddress);
-                mail.ReplyToList = new MailAddress(emailFromAddress, emailFromAddress);
+                mail.ReplyToList.Add = new MailAddress(emailFromAddress, emailFromAddress);
                 mail.To.Clear();
                 mail.Subject = subject;
                 mail.Body = Regex.Replace(builtString, "{[A-za-z]*}", " "); // Final cleanup


### PR DESCRIPTION
As per request https://github.com/Cloud9Developer/Jellyfin-Newsletter-Plugin/issues/78

Duplicated the 'From' value into 'Reply To' for email messages. Can be adjusted later if the option to add a separate 'Reply To' email value in the configuration screen is implemented.